### PR TITLE
アイコンアップロード機能

### DIFF
--- a/app/private/profile/actions.ts
+++ b/app/private/profile/actions.ts
@@ -24,3 +24,105 @@ export async function updateUsername(formData: FormData) {
 
   revalidatePath('/private/profile')
 }
+
+export async function updateIcon(formData: FormData) {
+  try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      throw new Error('ログインしてください')
+    }
+
+    const file = formData.get('icon') as File
+    if (!file) {
+      throw new Error('ファイルが選択されていません')
+    }
+
+    // ファイルサイズのチェック（5MB以下）
+    if (file.size > 5 * 1024 * 1024) {
+      throw new Error('ファイルサイズは5MB以下にしてください')
+    }
+
+    // ファイル形式のチェック
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/gif']
+    if (!allowedTypes.includes(file.type)) {
+      throw new Error('JPEG、PNG、またはGIF形式の画像のみアップロード可能です')
+    }
+
+    // ファイルをArrayBufferに変換
+    const arrayBuffer = await file.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+
+    // 一意のファイル名を生成（ユーザーID + タイムスタンプ）
+    const fileExt = file.name.split('.').pop()
+    const fileName = `${user.id}-${Date.now()}.${fileExt}`
+
+    console.log('アップロード開始:', {
+      bucket: 'avatar',
+      fileName,
+      fileType: file.type,
+      fileSize: file.size
+    })
+
+    // ストレージにアップロード
+    const { data: uploadData, error: uploadError } = await supabase.storage
+      .from('avatar')
+      .upload(fileName, buffer, {
+        contentType: file.type,
+        cacheControl: '3600',
+        upsert: false
+      })
+
+    if (uploadError) {
+      console.error('アップロードエラー詳細:', {
+        error: uploadError,
+        message: uploadError.message
+      })
+      
+      if (uploadError.message.includes('permission denied')) {
+        throw new Error('ファイルのアップロード権限がありません。管理者に連絡してください。')
+      }
+      if (uploadError.message.includes('bucket not found')) {
+        throw new Error('ストレージバケットが見つかりません。管理者に連絡してください。')
+      }
+      throw new Error(`ファイルのアップロードに失敗しました: ${uploadError.message}`)
+    }
+
+    if (!uploadData) {
+      throw new Error('アップロードに失敗しました。データが正しく保存されませんでした。')
+    }
+
+    console.log('アップロード成功:', uploadData)
+
+    // アップロードしたファイルのURLを取得
+    const { data: { publicUrl } } = supabase.storage
+      .from('avatar')
+      .getPublicUrl(fileName)
+
+    if (!publicUrl) {
+      throw new Error('アップロードしたファイルのURLを取得できませんでした。')
+    }
+
+    console.log('パブリックURL取得:', publicUrl)
+
+    // プロフィールを更新
+    const { error: updateError } = await supabase
+      .from('profiles')
+      .update({ icon_url: publicUrl })
+      .eq('id', user.id)
+
+    if (updateError) {
+      console.error('プロフィール更新エラー詳細:', updateError)
+      throw new Error(`プロフィールの更新に失敗しました: ${updateError.message}`)
+    }
+
+    revalidatePath('/private/profile')
+    return { iconUrl: publicUrl }
+  } catch (error) {
+    console.error('アイコン更新エラー:', error)
+    if (error instanceof Error) {
+      throw new Error(error.message)
+    }
+    throw new Error('予期せぬエラーが発生しました')
+  }
+}

--- a/app/private/profile/icon-form.tsx
+++ b/app/private/profile/icon-form.tsx
@@ -1,0 +1,87 @@
+"use client"
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Pencil, Check, X } from "lucide-react";
+import { updateIcon } from "./actions";
+import Image from 'next/image'
+
+interface IconFormProps {
+  initialIcon: string | null;
+}
+
+export function IconForm({ initialIcon }: IconFormProps) {
+    const [isUploading, setIsUploading] = useState(false)
+    const [currentIcon, setCurrentIcon] = useState<string | null>(initialIcon)
+    const [error, setError] = useState<string | null>(null)
+  
+    const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      if (!file) return
+
+      // エラー状態をリセット
+      setError(null)
+  
+      setIsUploading(true)
+      const formData = new FormData()
+      formData.append('icon', file)
+  
+      try {
+        const result = await updateIcon(formData)
+        if (result?.iconUrl) {
+          setCurrentIcon(result.iconUrl)
+        }
+      } catch (error) {
+        console.error('アップロードエラー:', error)
+        setError(error instanceof Error ? error.message : 'アップロードに失敗しました')
+      } finally {
+        setIsUploading(false)
+      }
+    }
+
+    const handleButtonClick = () => {
+      const fileInput = document.getElementById('icon-upload') as HTMLInputElement
+      if (fileInput) {
+        fileInput.click()
+      }
+    }
+  
+    return (
+      <div className="flex flex-col items-center gap-4">
+        {currentIcon && (
+          <div className="relative w-24 h-24">
+            <Image
+              src={currentIcon}
+              alt="プロフィールアイコン"
+              fill
+              className="rounded-full object-cover"
+            />
+          </div>
+        )}
+        <input
+          type="file"
+          accept="image/jpeg,image/png,image/gif"
+          onChange={handleFileChange}
+          className="hidden"
+          id="icon-upload"
+          disabled={isUploading}
+          aria-label="アイコン画像を選択"
+        />
+        <div className="flex flex-col items-center gap-2">
+          <Button
+            variant="outline"
+            className="cursor-pointer"
+            disabled={isUploading}
+            aria-label={isUploading ? 'アップロード中...' : 'アイコンを変更'}
+            title={isUploading ? 'アップロード中...' : 'アイコンを変更'}
+            onClick={handleButtonClick}
+          >
+            {isUploading ? 'アップロード中...' : 'アイコンを変更'}
+          </Button>
+          {error && (
+            <p className="text-red-500 text-sm">{error}</p>
+          )}
+        </div>
+      </div>
+    )
+  }

--- a/app/private/profile/page.tsx
+++ b/app/private/profile/page.tsx
@@ -3,7 +3,7 @@ import { createClient } from '@/utils/supabase/server';
 // ユーザーがログインしていない場合にリダイレクトするための関数をインポート
 import { redirect } from 'next/navigation';
 import { UsernameForm } from "./username-form";
-
+import { IconForm } from "./icon-form";
 export default async function Profile() {
   // supabaseクライアントを作成する
   const supabase = await createClient()
@@ -17,7 +17,7 @@ export default async function Profile() {
   // ユーザーのプロフィールデータを取得する
   let { data: profiles, error: profileError } = await supabase
     .from('profiles')
-    .select('username')
+    .select('username, icon_url')
     .eq('id', data.user.id)
     .single();
 
@@ -28,18 +28,26 @@ export default async function Profile() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen">
-      <h1 className="text-2xl font-bold mb-4">プロフィール</h1>
-      <div className="flex flex-col gap-4">
-        <div className="bg-gray-800 p-6 rounded-lg shadow-md">
-          <div className="flex items-center gap-2">
-            <p className="text-lg">ユーザー名: {username || '未設定'}</p>
-            <UsernameForm initialUsername={username} />
-          </div>
+    <h1 className="text-2xl font-bold mb-4">プロフィール</h1>
+    <div className="flex flex-col gap-4">
+      <div className="bg-gray-800 p-6 rounded-lg shadow-md">
+        <div className="flex items-center gap-2">
+          <p className="text-lg">ユーザー名: {username || '未設定'}</p>
+          <UsernameForm initialUsername={username} />
         </div>
-        <div className="bg-gray-800 p-6 rounded-lg shadow-md">
+      </div>
+      <div className="bg-gray-800 p-6 rounded-lg shadow-md">
+        <div className="flex items-center gap-2">
           <p className="text-lg">メールアドレス: {email || '未設定'}</p>
         </div>
       </div>
+      <div className="bg-gray-800 p-6 rounded-lg shadow-md">
+        <div className="flex items-center gap-2">
+          <p className="text-lg">アイコン</p>
+          <IconForm initialIcon={profiles?.icon_url} />
+        </div>
+      </div>
+    </div>
     </div>
   )
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,15 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'kcrmrvkofdawfeqmfecf.supabase.co',
+        port: '',
+        pathname: '/storage/v1/object/public/**',
+      },
+    ],
+  },
+}
+
+module.exports = nextConfig 


### PR DESCRIPTION
## プロフィールアイコンのアップロード
- app/private/profile/actions.ts に updateIcon 関数を追加し、アイコンのアップロード処理を実装しました。これには、ファイルサイズやファイルタイプの検証、並びにストレージ操作でのエラーハンドリングが含まれます。
アイコン管理のためのフロントエンドUI:
- app/private/profile/icon-form.tsx に IconForm コンポーネントを導入しました。このコンポーネントにより、ユーザーは新しいプロフィールアイコンをアップロードでき、現在のアイコンが表示され、アップロード時のエラーが適切に処理されます。
## プロフィールページとの統合
プロフィールページのアップデート:
- app/private/profile/page.tsx を修正し、IconForm コンポーネントを組み込み、ユーザーの現在のプロフィールアイコンを表示するようにしました。
- プロフィールページ用のデータベースクエリを更新し、ユーザー名とともに icon_url を取得するように変更しました。
- app/private/profile/page.tsx に IconForm の import 文を追加しました。
