### PR TITLE
ヘッダー変更

### DIFF
--- a/app/(main)/_components/(mypage)/header-menu.tsx
+++ b/app/(main)/_components/(mypage)/header-menu.tsx
@@ -1,0 +1,55 @@
+"use client";
+import Image from "next/image";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { useIsMobile } from '@/hooks/use-mobile';
+import { Menu } from 'lucide-react';
+import { useState } from 'react';
+import { createClient } from "@/utils/supabase/client";
+import { useRouter } from "next/navigation";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+
+export default function Headermenu() {
+    const supabase = createClient()
+    const router = useRouter()
+
+    const handleLogout = async () => {
+        await supabase.auth.signOut()
+        router.push('/')  // ルートパスへリダイレクト
+    }   
+  const [open, setOpen] = useState(false);
+
+    return (
+      <div className="pr-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="icon" className="border cursor-pointer">
+              <Menu size={36} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="p-1">
+            <DropdownMenuItem asChild>
+              <Link href="/private">マイページ</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="private/profile">プロフィール</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/private">あなたの釣果</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="private/areas">お気に入り釣り場</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleLogout}>
+                ログアウト
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+  }

--- a/app/(main)/_components/(mypage)/profile-set.tsx
+++ b/app/(main)/_components/(mypage)/profile-set.tsx
@@ -1,0 +1,40 @@
+"use client";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { createClient } from "@/utils/supabase/client";
+
+export default function ProfileSet() {
+  const [iconUrl, setIconUrl] = useState("/image/placeholder.png");
+  const [username, setUsername] = useState("");
+
+  useEffect(() => {
+    const supabase = createClient();
+    const fetchProfile = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        const { data: profile } = await supabase
+          .from("profiles")
+          .select("icon_url, username")
+          .eq("id", user.id)
+          .single();
+        setIconUrl(profile?.icon_url || "/image/placeholder.png");
+        setUsername(profile?.username || "");
+      }
+    };
+    fetchProfile();
+  }, []);
+
+  return (
+    <div className="flex items-center gap-5 p-1 rounded-md">
+      <div className="w-15 h-15 relative">
+        <Image
+          src={iconUrl}
+          alt="プロフィールアイコン"
+          fill
+          className="rounded-full object-cover"
+        />
+      </div>
+      <span className="font-semibold text-white leading-tight">{username}</span>
+    </div>
+  );
+}

--- a/app/(main)/_components/header.tsx
+++ b/app/(main)/_components/header.tsx
@@ -3,14 +3,11 @@ import GuestDialog from "./guest-dialog";
 import React, { useState } from "react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import Link from "next/link";
-import { SearchIcon } from "lucide-react";
-import { login } from '../../login/actions';
 import { createClient } from "@/utils/supabase/client";
 import { useEffect } from "react";
 import LoginDialog from "./login-dialog";
-
+import ProfileSet from "./(mypage)/profile-set";
 export default function Header() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
   const supabase = createClient()
@@ -32,22 +29,12 @@ export default function Header() {
 
   if (isLoggedIn) {
     return (
-      <header className="flex items-center justify-between pl-2 pt-2 shadow-sm">
+      <header className="flex items-center justify-between p-2 shadow-sm">
         <Link href="/">
             <Image src="/image/logo2.png" alt="ロゴ" width={100} height={100} />
         </Link>
-        <div className="relative p-3">
-            <Input placeholder="室蘭港" className="pl-10"/>
-            <SearchIcon className="absolute top-1/2 left-3 -translate-y-1/2 text-gray-400" />
-        </div>
-        <div className="flex">
-        <Button variant="outline" className="mr-3">
-          <Link href="/private">
-            マイページ
-          </Link>
-        </Button>
+        <ProfileSet />
         <LoginDialog/>
-        </div>
     </header>
     )
   }
@@ -57,10 +44,6 @@ export default function Header() {
         <Link href="/">
             <Image src="/image/logo2.png" alt="ロゴ" width={100} height={100} />
         </Link>
-        <div className="relative p-3">
-            <Input placeholder="室蘭港" className="pl-10"/>
-            <SearchIcon className="absolute top-1/2 left-3 -translate-y-1/2 text-gray-400" />
-        </div>
         <div className="flex">
         <GuestDialog/>
         </div>

--- a/app/(main)/_components/login-dialog.tsx
+++ b/app/(main)/_components/login-dialog.tsx
@@ -1,19 +1,8 @@
 "use client";
-import { Button } from "@/components/ui/button";
-import { createClient } from "@/utils/supabase/client";
-import { useRouter } from "next/navigation";
-
+import HeaderMenu from "./(mypage)/header-menu";
 export default function LoginDialog() {
-    const supabase = createClient()
-    const router = useRouter()
 
-    const handleLogout = async () => {
-        await supabase.auth.signOut()
-        router.push('/')  // ルートパスへリダイレクト
-    }   
     return (
-        <Button className="cursor-pointer mr-3" onClick={handleLogout}>
-            ログアウト
-        </Button>
+        <HeaderMenu />
     );
 }

--- a/app/private/page.tsx
+++ b/app/private/page.tsx
@@ -22,10 +22,7 @@ export default async function PrivatePage() {
 
   return (
    <div className="grid grid-cols-5">
-      <div className="col-span-1 m-5">
-        <Mymenu />
-      </div>
-      <div className="col-span-3 m-5 flex justify-center">
+      <div className="col-span-5 m-5 flex justify-center">
         <div className="w-auto">
           <Mycatch />
         </div>

--- a/app/private/profile/icon-form.tsx
+++ b/app/private/profile/icon-form.tsx
@@ -68,6 +68,7 @@ export function IconForm({ initialIcon }: IconFormProps) {
           aria-label="アイコン画像を選択"
         />
         <div className="flex flex-col items-center gap-2">
+          
           <Button
             variant="outline"
             className="cursor-pointer"
@@ -78,6 +79,7 @@ export function IconForm({ initialIcon }: IconFormProps) {
           >
             {isUploading ? 'アップロード中...' : 'アイコンを変更'}
           </Button>
+          <p className="text-xs text-gray-400 mb-1">※ サイズは1MBまでの gif, png, jpeg 形式のみ対応</p>
           {error && (
             <p className="text-red-500 text-sm">{error}</p>
           )}


### PR DESCRIPTION
## 新しいコンポーネントと機能
- ヘッダーメニューコンポーネント（header-menu.tsx）:
ログインしているユーザー向けにドロップダウンメニューを追加し、「マイページ」「プロフィール」「お気に入り釣り場」などの各ページへのナビゲーションやログアウトオプションを提供します。これにより、従来の静的なボタンが置き換えられます。
- プロフィール表示コンポーネント（profile-set.tsx）:
Supabaseのprofilesテーブルからデータを取得し、ユーザーのプロフィールアイコンとユーザー名を表示するコンポーネントを導入しました。
## 統合とリファクタリング
- Headerコンポーネント（header.tsx）:
ログインユーザー向けの静的な「マイページ」ボタンを、新しいProfileSetコンポーネントに置き換え、ナビゲーション向上のためにHeaderMenuコンポーネントを統合しました。また、不要なインポート文を削除し、レイアウトを簡素化しています。
- Loginダイアログ（login-dialog.tsx）:
従来のログアウトボタンの実装を削除し、代わりにHeaderMenuコンポーネントを取り込むようリファクタリングしました。
## レイアウト調整
- プライベートページのレイアウト（page.tsx）:
グリッドレイアウトを調整し、コンテンツが全幅に広がるように変更するとともに、サイドメニューのカラムを削除しました。
## UI強化
- アイコンフォーム（icon-form.tsx）:
アップロードボタンの下に、プロフィールアイコンのファイルサイズやフォーマットの制限についてユーザーへ通知するための注記を追加しました。
