### PR TITLE
画像サイズ上限変更

### DIFF
--- a/app/post/catch-post-form.tsx
+++ b/app/post/catch-post-form.tsx
@@ -65,7 +65,7 @@ export default function CatchPostForm() {
       let imageUrl = null;
       if (values.image && values.image.length > 0) {
         const file = values.image[0];
-        if (file.size > 1024 * 1024) throw new Error("画像サイズは1MBまでです");
+        if (file.size > 50 * 1024 * 1024) throw new Error("画像サイズは50MBまでです");
         const fileExt = file.name.split('.').pop();
         const fileName = `${crypto.randomUUID()}-${Date.now()}.${fileExt}`;
         const { data, error: uploadError } = await supabase.storage
@@ -95,6 +95,7 @@ export default function CatchPostForm() {
       form.reset();
       setImagePreview(null);
       router.refresh();
+      router.push('/private');
     } catch (err: any) {
       setError(err.message || "投稿に失敗しました");
     } finally {

--- a/app/private/profile/icon-form.tsx
+++ b/app/private/profile/icon-form.tsx
@@ -79,7 +79,7 @@ export function IconForm({ initialIcon }: IconFormProps) {
           >
             {isUploading ? 'アップロード中...' : 'アイコンを変更'}
           </Button>
-          <p className="text-xs text-gray-400 mb-1">※ サイズは1MBまでの gif, png, jpeg 形式のみ対応</p>
+          <p className="text-xs text-gray-400 mb-1">※ gif, png, jpeg 形式のみ対応</p>
           {error && (
             <p className="text-red-500 text-sm">{error}</p>
           )}

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '50mb',
+    },
+  },
   images: {
     remotePatterns: [
       {
@@ -12,4 +17,4 @@ const nextConfig = {
   },
 }
 
-module.exports = nextConfig 
+module.exports = nextConfig;


### PR DESCRIPTION
# 画像サイズの変更
- 画像サイズはsupabase上限の50MBまでとする。
- next.config.jsにbodySizeLimit: '50mb'を追加。
- プロフィール画像の※書き変更